### PR TITLE
Add test cases for strings with padding chars inbetween and check for url safe characters; fixes#3

### DIFF
--- a/test.js
+++ b/test.js
@@ -216,3 +216,14 @@ const base64Decode = require('./')
 
   assert.strictEqual(actual.join(), expected.join())
 }
+
+{
+  const actual = new Uint8Array(9)
+  const expected = new Uint8Array([0xff, 0xff, 0xbe, 0xff, 0xef, 0xbf, 0xfb, 0xef, 0xff])
+
+  base64Decode('//++/++/++//', actual)
+  assert.strictEqual(actual.join(), expected.join())
+
+  base64Decode('__--_--_--__', actual)
+  assert.strictEqual(actual.join(), expected.join())
+}

--- a/test.js
+++ b/test.js
@@ -207,3 +207,12 @@ const base64Decode = require('./')
 
   assert.strictEqual(actual.join(), expected.join())
 }
+
+{
+  const actual = new Uint8Array(1)
+  const expected = new Uint8Array([73])
+
+  base64Decode('SQ==QU0=', actual)
+
+  assert.strictEqual(actual.join(), expected.join())
+}

--- a/test.js
+++ b/test.js
@@ -198,3 +198,12 @@ const base64Decode = require('./')
 
   assert.strictEqual(actual.join(), expected.join())
 }
+
+{
+  const actual = new Uint8Array(64)
+  const expected = new Uint8Array(64)
+
+  base64Decode('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==', expected)
+
+  assert.strictEqual(actual.join(), expected.join())
+}


### PR DESCRIPTION
Changes: 
- Added a 64 bit string to decode
- added a test case of a base64 string with padding in between
- check for decoding of url safe strings

Review:
- imo the 64 bit array doesn't constitute for the big-data test since it isn't nearly big enough
Thoughts ? 